### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,3 +4,4 @@ services:
   env: static
   buildCommand: yarn && yarn build
   staticPublishPath: .vuepress/dist
+  autoDeploy: false


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed from this public repo.

However, merging this PR will trigger a final forced deployment of any instances created and deployed from this repo.

Signed-off-by: zach wick <zach@render.com>